### PR TITLE
Fix deprecated volatile compound assignment for C++20 compliance

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -639,7 +639,8 @@ void Task::setIterations(long aIterations) {
     iMutex = iMutex + 1;
 #endif  // _TASK_THREAD_SAFE
 
-    iSetIterations = iIterations = aIterations;
+    iIterations = aIterations;
+    iSetIterations = iIterations;
 
 #ifdef _TASK_THREAD_SAFE
     iMutex = iMutex - 1;


### PR DESCRIPTION
### Summary

This PR resolves compiler warnings related to deprecated usage of chained assignment on `volatile` variables, which became an issue in C++20 and later.

### Details

- Replaces statements like:
  ```cpp
  iSetIterations = iIterations = aIterations;
  
  iIterations = aIterations;
  iSetIterations = iIterations;
  ```
